### PR TITLE
chore: add catalog-info.yaml (WK Backstage metadata)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,23 +1,28 @@
+---
 # Wolters Kluwer Backstage compliant catalog info
 # See https://backstage.io/docs/features/software-catalog/descriptor-format
 apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
   name: jdbf
-  description: "Java utility to read/write DBF files - voor ClearFacts Bob50 Connector"
+  description: "Java utility to read/write DBF files - voor ClearFacts Bob50 Co\
+    nnector"
   annotations:
-    wolterskluwer.io/bit-id: "041800002496"
+    wolterskluwer.io/bit-id: '041800002496'
 spec:
   type: library
   lifecycle: production
   owner: Glenn.Van-Den-Broeck@wolterskluwer.com
 links:
-  - url: https://sonarqube.cloud-dev.wolterskluwer.eu/dashboard?id=clearfacts%3Ajdbf
+  - url: "https://sonarqube.cloud-dev.wolterskluwer.eu/dashboard?id=clearfacts%\
+    3Ajdbf"
     type: SAST
     title: SonarQube
-  - url: https://wolterskluwer.app.blackduck.com/api/projects/82ad2558-5d57-44bf-9fbc-372e3d8d6a19
+  - url: "https://wolterskluwer.app.blackduck.com/api/projects/82ad2558-5d57-44\
+    bf-9fbc-372e3d8d6a19"
     type: SCA
     title: Black Duck
-  - url: https://test4tools.cchaxcess.com/CxWebClient/ProjectStateSummary.aspx?projectid=17866
+  - url: "https://test4tools.cchaxcess.com/CxWebClient/ProjectStateSummary.aspx\
+    ?projectid=17866"
     type: SAST
     title: Checkmarx

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,23 @@
+# Wolters Kluwer Backstage compliant catalog info
+# See https://backstage.io/docs/features/software-catalog/descriptor-format
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: jdbf
+  description: "Java utility to read/write DBF files - voor ClearFacts Bob50 Connector"
+  annotations:
+    wolterskluwer.io/bit-id: "041800002496"
+spec:
+  type: library
+  lifecycle: production
+  owner: Glenn.Van-Den-Broeck@wolterskluwer.com
+links:
+  - url: https://sonarqube.cloud-dev.wolterskluwer.eu/dashboard?id=clearfacts%3Ajdbf
+    type: SAST
+    title: SonarQube
+  - url: https://wolterskluwer.app.blackduck.com/api/projects/82ad2558-5d57-44bf-9fbc-372e3d8d6a19
+    type: SCA
+    title: Black Duck
+  - url: https://test4tools.cchaxcess.com/CxWebClient/ProjectStateSummary.aspx?projectid=17866
+    type: SAST
+    title: Checkmarx


### PR DESCRIPTION
Adds `catalog-info.yaml` at the repo root per the WK Metadata Marker File spec (Backstage-compatible).

- `metadata.name`: repo name
- `metadata.annotations.wolterskluwer.io/bit-id`: extracted from the README `Barometer IT` link (falls back to `041800002496` when not present in README)
- `spec.type`: inferred from repo purpose (service / library / infrastructure / pipeline / documentation / desktop / test-automation)
- `spec.lifecycle`: `production` for customer-facing repos, `support` for repos flagged `[x] non-production code only` in the README or with only SDLC/tooling scope (also `cf-operations`)
- `spec.owner`: `Glenn.Van-Den-Broeck@wolterskluwer.com`
- `links[]`: extracted from the README `## Technical debt links` section (SonarQube = SAST, Black Duck = SCA, Checkmarx = SAST); omitted when the README flags the repo as non-production or SCA-not-applicable

Spec reference: https://confluence.wolterskluwer.io/spaces/DAACCE/pages/934545428/